### PR TITLE
Remove padding from the Enable button

### DIFF
--- a/resources/views/enable-two-factor-auth.blade.php
+++ b/resources/views/enable-two-factor-auth.blade.php
@@ -12,22 +12,18 @@
 
             <form class="form-horizontal" role="form">
                 <!-- Enable Button -->
-                <div class="form-group">
-                    <div class="col-md-offset-4 col-md-6">
-                        <button type="submit" class="btn btn-primary"
-                                @click.prevent="enable"
-                                :disabled="form.busy">
+                <button type="submit" class="btn btn-primary"
+                        @click.prevent="enable"
+                        :disabled="form.busy">
 
-                            <span v-if="form.busy">
-                                <i class="fa fa-btn fa-spinner fa-spin"></i>Enabling
-                            </span>
+                    <span v-if="form.busy">
+                        <i class="fa fa-btn fa-spinner fa-spin"></i>Enabling
+                    </span>
 
-                            <span v-else>
-                                Enable
-                            </span>
-                        </button>
-                    </div>
-                </div>
+                    <span v-else>
+                        Enable
+                    </span>
+                </button>
             </form>
         </div>
     </div>


### PR DESCRIPTION
Looks kinda odd to me with it sitting there in the middle.

Before:

![image](https://cloud.githubusercontent.com/assets/510740/14657677/31d7fd56-0687-11e6-868f-1ebe774e85d4.png)

After:

![image](https://cloud.githubusercontent.com/assets/510740/14657704/39138a4a-0687-11e6-9eac-505f0ca992d0.png)
