### PR TITLE
Add support for a custom Display Name in the authenticator app

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,13 @@ This package replaces the default Two-Factor Authentication driver with [Google 
 - Edit `resources/assets/js/spark-components/settings/security/enable-two-factor-auth.js` and replace `require('settings/security/enable-two-factor-auth')` with `require('./enable-two-factor-auth-google')`
 
 - Run `npm run dev`
+
+## Customise the display name
+
+The display name in the authenticator app is chosen from the ```$details``` section in your ```SparkServiceProvider``` file.
+
+The following order is used, the first variable that's found will be the display name.
+
+1. ```$details['2fa_name']``` (not present by default)
+2. ```$details['vendor']``` (present by default)
+3. the domain name (safe fallback)

--- a/src/TwoFactorAuthController.php
+++ b/src/TwoFactorAuthController.php
@@ -51,7 +51,18 @@ class TwoFactorAuthController extends Controller
      */
     protected function getQrUrl($email, $secret)
     {
-        $company = isset(Spark::$details['vendor']) ? urlencode(Spark::$details['vendor']) : url()->to('/');
+        # If the user defined a custom "2fa_name" detail, use that
+        if (isset(Spark::$details['2fa_name'])) {
+            $company = urlencode(Spark::$details['2fa_name']);
+        }
+        # Otherwise, see if the Vendor is filled in
+        elseif (isset(Spark::$details['vendor'])) {
+            $company = urlencode(Spark::$details['vendor']);
+        }
+        # If it isn't, use the domain name as 2FA name
+        else {
+            $company = url()->to('/');
+        }
 
         return str_replace('200x200', '260x260', (new Google2FA)->getQRCodeGoogleUrl($company, $email, $secret));
     }


### PR DESCRIPTION
I use this because my invoices will mention Company X, whereas the product is titled differently.

Alternatively, I think a sane default value would be $details['product'] instead of $details['vendor'], but this way it's configurable.